### PR TITLE
Fix async-interop version constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,14 +11,14 @@
     "homepage": "http://amphp.org",
     "license": "MIT",
     "require": {
-        "async-interop/event-loop": "0.5"
+        "async-interop/event-loop": "^0.5"
     },
     "require-dev": {
         "async-interop/event-loop-test": "^0.5",
         "friendsofphp/php-cs-fixer": "~1.9"
     },
     "provide": {
-        "async-interop/event-loop-implementation": "^0.5"
+        "async-interop/event-loop-implementation": "0.5"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
The Composer config file looks slightly wrong. `provide` should list exact versions, not constraints, whereas `require` should use constraints.